### PR TITLE
Updated FreeBSD installation page and made some small edits to Archlinux page

### DIFF
--- a/pages/install_dart_on_archlinux.md
+++ b/pages/install_dart_on_archlinux.md
@@ -1,12 +1,12 @@
 ---
 title: Install DART on Archlinux
 keywords: install, archlinux
-last_updated: Apr 29, 2019
+last_updated: Apr 30, 2019
 sidebar: home_sidebar
 permalink: install_dart_on_archlinux.html
 ---
 
-{% include warning.html content="Installing DART on Archlinux is not tested by the DART developers." %}
+{% include note.html content="Installing DART on Archlinux is not tested by the DART developers." %}
 
 ## Install DART from the [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository)
 
@@ -19,7 +19,7 @@ or use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers)
 (recommended for ease of install).
 
 To discuss any issues related to this package refer to the comments section on
-the AUR page of 'libdart' [here](https://aur.archlinux.org/packages/libdart/).
+the AUR page of `libdart` [here](https://aur.archlinux.org/packages/libdart/).
 
 ## Install DART from Source
 
@@ -29,8 +29,8 @@ the AUR page of 'libdart' [here](https://aur.archlinux.org/packages/libdart/).
 sudo pacman -Sy assimp boost glut libgl eigen
 ```
 
-The following required dependencies are not available on the Arch Linux supported
-repositories, however they are available on the AUR or you can install them from
+The following required dependencies are not available in the Arch Linux supported
+repositories, however they are available in the AUR or you can install them from
 source.
 
 ```
@@ -40,16 +40,20 @@ fcl flann libccd octomap urdfdom
 ### Install Optional Dependencies
 
 ```
-sudo pacman -Sy bullet nlopt ode openscenegraph
+sudo pacman -Sy bullet doxygen nlopt ode openscenegraph
 ```
 
-The following required dependency is not available on the Arch Linux supported
-repositories, however it is available on the AUR or you can install it from
+The following optional dependency is not available in the Arch Linux supported
+repositories, however it is available in the AUR or you can install it from
 source.
 
 ```
 coin-or-ipopt
 ```
+
+`pagmo` is an optional dependency not available in the Arch Linux supported
+repositories or the AUR. Refer to the `pagmo` [installation page](https://esa.github.io/pagmo2/install.html#)
+for installation instructions.
 
 ### Build and Install DART
 
@@ -95,19 +99,19 @@ coin-or-ipopt
       Once you successfully build the tests, you can run all the tests at once as:
 
       ```shell
-      $ make -j4 test  # or cmake -j4
+      make -j4 test  # or cmake -j4
       ```
 
       or run a particular test as:
 
       ```shell
-      $ ./unittests/<category_name>/<test_name>  # e.g., ./unittests/unit/test_Uri
+      ./unittests/<category_name>/<test_name>  # e.g., ./unittests/unit/test_Uri
       ```
 
       Also, you can run tutorials and examples as:
 
       ```shell
-      $ ./bin/<executable_name>  # e.g., ./bin/rigidCubes
+      ./bin/<executable_name>  # e.g., ./bin/rigidCubes
       ```
 
   * Build Type

--- a/pages/install_dart_on_freebsd.md
+++ b/pages/install_dart_on_freebsd.md
@@ -1,26 +1,36 @@
 ---
 title: Install DART on FreeBSD
 keywords: install, freebsd
-last_updated: Apr 26, 2019
+last_updated: Apr 30, 2019
 sidebar: home_sidebar
 permalink: install_dart_on_freebsd.html
 ---
 
-{% include warning.html content="Installing DART on FreeBSD is not tested by the DART developers. Following intstructions are written based on the FreeBSD documents. If someone can verify this instructions, then please feel free to submit PRs removing this warning or adding any updates." %}
+{% include note.html content="Installing DART on FreeBSD is not tested by the DART developers." %}
 
 ## Install DART using [pkg](https://www.freebsd.org/doc/handbook/pkgng-intro.html)
 
 ```
-# pkg install dartsim
+pkg install dartsim
 ```
 
 ## Install DART from Source
 
-### Install Dependencies
+### Install Required Dependencies
 
 ```
-# pkg install assimp boost fcl flann glut libccd libgl octomap urdfdom eigen
+pkg install assimp boost fcl flann glut libccd libgl octomap urdfdom eigen
 ```
+
+### Install Optional Dependencies
+
+```
+pkg install bullet doxygen ipopt nlopt ode
+```
+
+`pagmo` is an optional dependency not available as a FreeBSD Port. Refer to
+the `pagmo` [installation page](https://esa.github.io/pagmo2/install.html#)
+for installation instructions.
 
 ### Build and Install DART
 
@@ -66,19 +76,19 @@ permalink: install_dart_on_freebsd.html
       Once you successfully build the tests, you can run all the tests at once as:
 
       ```shell
-      $ make -j4 test  # or cmake -j4
+      make -j4 test  # or cmake -j4
       ```
 
       or run a particular test as:
 
       ```shell
-      $ ./unittests/<category_name>/<test_name>  # e.g., ./unittests/unit/test_Uri
+      ./unittests/<category_name>/<test_name>  # e.g., ./unittests/unit/test_Uri
       ```
 
       Also, you can run tutorials and examples as:
 
       ```shell
-      $ ./bin/<executable_name>  # e.g., ./bin/rigidCubes
+      ./bin/<executable_name>  # e.g., ./bin/rigidCubes
       ```
 
   * Build Type
@@ -91,7 +101,7 @@ permalink: install_dart_on_freebsd.html
 
     The default build type is `Release`.
 
-1.  Install DART:
+5.  Install DART:
 
     ```
     sudo make install


### PR DESCRIPTION
Some small edits made to the Archlinux page.

Updates made to required and optional dependencies on FreeBSD page based on available ports from the FreeBSD repository index. I haven't tested the FreeBSD install myself, but am fairly confident with the updates.

Also updated the Archlinux and FreeBSD page code blocks to not include '$' & '#' to make it easier for people to copy and paste.
