### PR TITLE
Redirect root page to Read the Docs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,10 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.site_title }}</title>
+{% if page.redirect_to %}
+<link rel="canonical" href="{{ page.redirect_to | escape }}">
+<meta http-equiv="refresh" content="0; url={{ page.redirect_to | escape }}">
+{% endif %}
 <link rel="stylesheet" href="{{ "css/syntax.css" }}">
 
 

--- a/index.md
+++ b/index.md
@@ -1,67 +1,18 @@
 ---
+title: DART Documentation
 keywords: home introduction
 sidebar: mydoc_sidebar
 permalink: index.html
 toc: false
+redirect_to: https://dart.readthedocs.io/
 ---
 
-{% include image.html file="dart_logo_big.jpg" alt="DART Logo" max-width="320"  caption="" %}
+# DART documentation has moved
 
+The maintained DART documentation site is now
+[https://dart.readthedocs.io/](https://dart.readthedocs.io/).
 
-## Introduction
+This root page redirects to Read the Docs. Existing deep links on this legacy
+site remain available while their content is migrated.
 
-DART (Dynamic Animation and Robotics Toolkit) is a collaborative, cross-platform, open-source library developed by the [Graphics Lab](http://www.cc.gatech.edu/~karenliu/Home.html) and [Humanoid Robotics Lab](http://www.golems.org/) at the [Georgia Institute of Technology](http://www.gatech.edu/), with ongoing contributions from the [Personal Robotics Lab](http://personalrobotics.cs.washington.edu/) at the [University of Washington](http://www.washington.edu/) and the [Open Source Robotics Foundation](https://www.osrfoundation.org/). It provides data structures and algorithms for kinematic and dynamic applications in robotics and computer animation. DART stands out due to its accuracy and stability, which are achieved through the use of generalized coordinates to represent articulated rigid body systems and the application of Featherstone's Articulated Body Algorithm to compute motion dynamics.
-
-For developers, DART offers full access to internal kinematic and dynamic quantities, such as the mass matrix, Coriolis and centrifugal forces, transformation matrices, and their derivatives, unlike many popular physics engines that treat the simulator as a black box. It also provides efficient computation of Jacobian matrices for arbitrary body points and coordinate frames. The frame semantics of DART allow users to define and use arbitrary reference frames (both inertial and non-inertial) to specify or request data.
-
-DART is suitable for real-time controllers due to its lazy evaluation, which automatically updates forward kinematics and dynamics values to ensure code safety. It also allows for the extension of the API to embed user-provided classes into DART data structures. Contacts and collisions are handled using an implicit time-stepping, velocity-based linear complementarity problem (LCP) to guarantee non-penetration, directional friction, and approximated Coulomb friction cone conditions.
-
-In summary, DART has applications in robotics and computer animation as it features a multibody dynamic simulator and various kinematic tools for control and motion planning.
-
-## Features
-
-### General
-
-* Open-source C++ library licensed under the BSD license.
-* Supports multiple platforms including Ubuntu, Archlinux, FreeBSD, macOS, and Windows.
-* Fully integrated with Gazebo.
-* Supports models in URDF and SDF formats.
-* Provides default integration methods (semi-implicit Euler and RK4) and an extensible API for other numerical integration methods.
-* Supports lazy evaluation and automatic updates of kinematic and dynamic quantities.
-* Allows for the extension of the API to embed user-provided classes into its data structures.
-* Provides comprehensive event recording in the simulation history.
-* 3D visualization API using OpenGL and OpenSceneGraph with ImGui support.
-* Extensible API to interface with various optimization problems, such as nonlinear programming and multi-objective optimization.
-
-### Collision Detection
-
-* Support for multiple collision detectors: FCL, Bullet, and ODE.
-* Support for various collision shapes including primitive shapes, concave mesh, and probabilistic voxel grid.
-* Support for minimum distance computation.
-
-### Kinematics
-
-* Support for numerous types of Joints.
-* Support for numerous primitive and arbitrary body shapes with customizable inertial and material properties.
-* Support for flexible skeleton modeling, including cloning and reconfiguring skeletons or subsections of a skeleton.
-* Comprehensive access to kinematic states (e.g. transformation, position, velocity, or acceleration) of arbitrary entities and coordinate frames.
-* Comprehensive access to various Jacobian matrices and their derivatives.
-* Flexible conversion of coordinate frames.
-* Fully modular inverse kinematics framework.
-* Plug-and-play hierarchical whole-body inverse kinematics solver.
-* Analytic inverse kinematics interface with ikfast support.
-
-### Dynamics
-
-* High performance for articulated dynamic systems using Lie Group representation and Featherstone hybrid algorithms.
-* Exact enforcement of joints between body nodes using generalized coordinates.
-* Comprehensive API for dynamic quantities and their derivatives, such as the mass matrix, Coriolis force, gravitational force, and other external and internal forces.
-* Support for both rigid and soft body nodes.
-* Modeling of viscoelastic joint dynamics with joint friction and hard joint limits.
-* Support for various types of actuators.
-* Handling of contacts and collisions using an implicit LCP to guarantee non-penetration, directional friction, and approximated Coulomb friction cone conditions.
-* Use of the "Island" technique to subdivide constraint handling for efficient performance.
-* Support for various Cartesian constraints and extensible API for user-defined constraints.
-* Multiple constraint solvers: Lemke method, Dantzig method, and PSG method.
-* Support for dynamic systems with closed-loop structures.
-
+If you are not redirected automatically, use the link above.


### PR DESCRIPTION
## Summary

- Redirect only the legacy website root page (`https://dartsim.github.io/`) to the maintained DART documentation at `https://dart.readthedocs.io/`.
- Leave existing deep links on the legacy site available while their content is migrated.

## Motivation / Problem

Discussion https://github.com/dartsim/dart/discussions/1927 identified confusion between the old `dartsim.github.io` website and the maintained Read the Docs site. A root-only redirect sends new users to the maintained documentation without breaking old deep links that may not have equivalent Read the Docs pages yet.

## Changes

- Add optional `redirect_to` front matter support in `_includes/head.html` using a canonical link and meta refresh.
- Replace the root `index.md` content with a short moved-docs notice and `redirect_to: https://dart.readthedocs.io/`.

## Testing

- `git diff --check`
- Not run: local Jekyll build. Ruby is not installed in this environment.

## Notes

This intentionally does not add a domain-wide or catch-all redirect, so legacy pages such as old tutorials can continue to resolve until they are migrated deliberately.

Related DART metadata/docs PR: https://github.com/dartsim/dart/pull/2702
