### PR TITLE
Add CI dashboard link

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -27,6 +27,8 @@ topnav_dropdowns:
       folderitems:
         - title: View DART on Github
           external_url: https://github.com/dartsim/dart
+        - title: CI Dashboard
+          external_url: https://dartsim.github.io/ci-dashboard/
         - title: Report DART Issue
           external_url: https://github.com/dartsim/dart/issues
 #         - title: View DART Website on Github


### PR DESCRIPTION
## Summary

- Add the public DART CI dashboard to the website GitHub dropdown.

## Validation

- Parsed `_data/topnav.yml` with Ruby YAML loader.
- Could not run `bundle exec jekyll build` locally because `bundle` is not installed in this environment.