### PR TITLE
Load CI dashboard data from dashboard repo

### DIFF
--- a/ci-status/app.js
+++ b/ci-status/app.js
@@ -1,4 +1,4 @@
-const statusUrl = "data/status.json";
+const statusUrl = document.currentScript?.dataset.statusUrl || "data/status.json";
 
 function formatDuration(seconds) {
   if (seconds === null || seconds === undefined) return "-";
@@ -168,6 +168,25 @@ async function load() {
 
     document.getElementById("generated-at").textContent = `Generated ${data.generated_at}`;
   } catch (error) {
+    if (statusUrl !== "data/status.json") {
+      try {
+        const response = await fetch(`data/status.json?t=${Date.now()}`, { cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        renderSummary(data);
+        renderWarnings(data);
+        renderRunnerPools(data);
+        renderJobs("queued-jobs", data.jobs?.queued, { empty: "No queued jobs." });
+        renderJobs("in-progress-jobs", data.jobs?.in_progress, { empty: "No in-progress jobs." });
+        renderJobs("gpu-jobs", data.jobs?.latest_gpu, { empty: "No recent CUDA/GPU jobs in the sample." });
+        renderJobs("recent-jobs", data.jobs?.recent_completed, { empty: "No completed jobs in the sample." });
+        document.getElementById("generated-at").textContent = `Generated ${data.generated_at}`;
+        return;
+      } catch (fallbackError) {
+        document.getElementById("summary").innerHTML = `<div class="error">Failed to load dashboard data: ${escapeHtml(error.message)}; fallback failed: ${escapeHtml(fallbackError.message)}</div>`;
+        return;
+      }
+    }
     document.getElementById("summary").innerHTML = `<div class="error">Failed to load dashboard data: ${escapeHtml(error.message)}</div>`;
   }
 }

--- a/ci-status/index.html
+++ b/ci-status/index.html
@@ -73,7 +73,9 @@
       <span>GitHub-hosted capacity is inferred from job state.</span>
     </footer>
 
-    <script src="app.js"></script>
+    <script
+      src="app.js"
+      data-status-url="https://raw.githubusercontent.com/dartsim/ci-dashboard/gh-pages/data/status.json"
+    ></script>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary

- Load `/ci-status/` dashboard data from `dartsim/ci-dashboard`'s generated `gh-pages` branch.
- Keep the website's committed `ci-status/data/status.json` as a fallback seed.

## Validation

- Checked dashboard JavaScript with `node --check ci-status/app.js`.
- Parsed fallback `ci-status/data/status.json` with `python3 -m json.tool`.
- Served the site locally and verified the dashboard page includes the raw data URL.
- Could not run `bundle exec jekyll build` locally because `bundle` is not installed in this environment.