### PR TITLE
Declare explicit Ruby >= 3.2 requirement (addresses #34 review)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
 source "https://rubygems.org"
 
+# Explicit floor aligned with the lockfile. The Dependabot security fix pulls
+# activesupport 8.1.3, which requires Ruby >= 3.2; even activesupport 7.2.3.1
+# (the lowest version that patches the advisories) needs >= 3.1, so EOL Ruby
+# 3.1/2.7 cannot be supported regardless. Matches GitHub Pages' Ruby 3.3.x.
+# The classic Pages build ignores this directive and the lockfile; it only
+# guards local `bundle install` / `jekyll serve` with a clear error.
+ruby ">= 3.2"
+
 # gem "rails"
 gem 'github-pages'
 gem 'jekyll', '>= 3.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,5 +310,8 @@ DEPENDENCIES
   github-pages
   jekyll (>= 3.6.3)
 
+RUBY VERSION
+   ruby 3.3.4p94
+
 BUNDLED WITH
    2.7.2


### PR DESCRIPTION
## Summary

Addresses the [Codex review comment on #34](https://github.com/dartsim/dartsim.github.io/pull/34#discussion_r): the committed `Gemfile.lock` resolves `activesupport 8.1.3`, whose gem metadata requires **Ruby ≥ 3.2**, so a fresh checkout on an older Ruby would fail `bundle install` / local Jekyll builds without a clear explanation.

## Change

- Add an explicit **`ruby ">= 3.2"`** floor to the `Gemfile` (with an explanatory comment). Bundler now fails fast with an actionable message on Ruby < 3.2 instead of a confusing transitive-gem resolution error.
- Regenerate `Gemfile.lock` on **Ruby 3.3.4** (matching GitHub Pages production), which records `RUBY VERSION   ruby 3.3.4p94`. **No gem versions change.**

## Why this option (declare the floor) rather than pinning activesupport down

The reviewer offered two options; declaring the floor is the better fit here:

- The Dependabot remediation requires `activesupport ≥ 7.2.3.1`, which **itself requires Ruby ≥ 3.1** — and the latest patched `8.1.3` requires ≥ 3.2. So **EOL Ruby 3.1 / 2.7 cannot be supported regardless** of which patched activesupport we pick; the floor is forced by the security fix, not a discretionary regression.
- Pinning a *transitive* dep (`activesupport ~> 7.2`) in the Gemfile only to chase EOL Ruby 3.1 would add a maintenance footgun and diverge from production, which runs the 8.x line on **Ruby 3.3.4**.

## Safety

- **Production unaffected.** The classic GitHub Pages build (no Actions in this repo) builds server-side with GitHub's own environment (Ruby 3.3.4 + github-pages 232) and ignores both the committed `Gemfile.lock` and the Gemfile `ruby` directive. The `>= 3.2` floor is a floor (not an exact pin) and is satisfied by 3.3.4.
- **No security regression.** Lock diff is metadata-only (the `RUBY VERSION` line); `addressable 2.9.0`, `activesupport 8.1.3`, `i18n 1.14.8`, `tzinfo 2.0.6` are unchanged, so all 9 Dependabot alerts remain resolved.

## Verification

`bundle install` + gem load verified in Ruby 3.3.4 and 3.4 containers (`jekyll 3.10.0`, `activesupport 8.1.3` load cleanly); on EOL Ruby 3.1 it fails fast as intended.
