### PR TITLE
Redirect superseded pages to readthedocs

### DIFF
--- a/pages/citing.md
+++ b/pages/citing.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/papers.html
 title: Citing DART
 sidebar: home_sidebar
 permalink: citing.html

--- a/pages/dartpy_examples/dartpy_examples_introduction.md
+++ b/pages/dartpy_examples/dartpy_examples_introduction.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/examples.html
 title: dartpy Examples
 keywords:
 sidebar: dartpy_examples_sidebar

--- a/pages/dartpy_examples/dartpy_examples_operational_space_control.md
+++ b/pages/dartpy_examples/dartpy_examples_operational_space_control.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/examples.html
 title: Rigid Cubes
 keywords: examples
 sidebar: dartpy_examples_sidebar

--- a/pages/dartpy_examples/dartpy_examples_operational_space_control.md
+++ b/pages/dartpy_examples/dartpy_examples_operational_space_control.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/examples.html
+redirect_to: https://github.com/dartsim/dart/blob/main/python/examples/demos/scenes/operational_space_control.py
 title: Rigid Cubes
 keywords: examples
 sidebar: dartpy_examples_sidebar

--- a/pages/dartpy_examples/dartpy_examples_rigid_cubes.md
+++ b/pages/dartpy_examples/dartpy_examples_rigid_cubes.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/examples.html
 title: Rigid Cubes
 keywords: examples
 sidebar: dartpy_examples_sidebar

--- a/pages/dartpy_examples/dartpy_examples_rigid_cubes.md
+++ b/pages/dartpy_examples/dartpy_examples_rigid_cubes.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/examples.html
+redirect_to: https://github.com/dartsim/dart/blob/main/python/examples/demos/scenes/rigid_cubes.py
 title: Rigid Cubes
 keywords: examples
 sidebar: dartpy_examples_sidebar

--- a/pages/gallery.md
+++ b/pages/gallery.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/gallery.html
 title: DART Gallery
 keywords: 
 tags: [getting_started]

--- a/pages/install_dart_on_archlinux.md
+++ b/pages/install_dart_on_archlinux.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on Archlinux
 keywords: install, archlinux
 last_updated: May 06, 2019

--- a/pages/install_dart_on_debian.md
+++ b/pages/install_dart_on_debian.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on Debian
 keywords: install, debian
 last_updated: Apr 26, 2019

--- a/pages/install_dart_on_freebsd.md
+++ b/pages/install_dart_on_freebsd.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on FreeBSD
 keywords: install, freebsd
 last_updated: Apr 30, 2019

--- a/pages/install_dart_on_mac.md
+++ b/pages/install_dart_on_mac.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on Mac
 keywords: install, mac
 last_updated: Apr 26, 2019

--- a/pages/install_dart_on_ubuntu.md
+++ b/pages/install_dart_on_ubuntu.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on Ubuntu
 keywords: install, ubuntu
 last_updated: Jan 10, 2019

--- a/pages/install_dart_on_windows.md
+++ b/pages/install_dart_on_windows.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dart/user_guide/installation.html
 title: Install DART on Windows
 permalink: install_dart_on_windows.html
 keywords: jekyll on windows, pc, ruby, ruby dev kit

--- a/pages/install_dartpy_on_macos.md
+++ b/pages/install_dartpy_on_macos.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/installation.html
 title: Install dartpy on macOS
 keywords:
 sidebar: home_sidebar

--- a/pages/install_dartpy_on_ubuntu.md
+++ b/pages/install_dartpy_on_ubuntu.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/dartpy/user_guide/installation.html
 title: Install dartpy on Ubuntu
 keywords:
 sidebar: home_sidebar

--- a/pages/license.md
+++ b/pages/license.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/license.html
 title: DART License
 sidebar: home_sidebar
 permalink: license.html

--- a/pages/mydoc_use_cases.md
+++ b/pages/mydoc_use_cases.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/community/who_uses_dart.html
 title: DART Use Cases
 keywords:
 sidebar: home_sidebar


### PR DESCRIPTION
## Summary

Part 1 of cleaning up `dartsim.github.io` now that the canonical docs live at **dart.readthedocs.io** (Sphinx, sourced from the `dart` repo).

**Problem:** today only the site *root* redirects to readthedocs. Every deep URL still serves stale 2015–2019 Jekyll content with no redirect.

This PR adds per-page `redirect_to` front matter (the existing `_includes/head.html` renders the canonical link + meta-refresh) so the **superseded pages** bounce to the best current target. Pages whose content is duplicated on RTD go to their RTD equivalent; the two example pages that hold example-specific code go to their exact, current source in the `dart` repo (per review feedback).

| Legacy page(s) | → target |
|---|---|
| `install_dart_on_{ubuntu,mac,windows,debian,archlinux,freebsd}` | RTD `dart/user_guide/installation` |
| `install_dartpy_on_{ubuntu,macos}` | RTD `dartpy/user_guide/installation` |
| `dartpy_examples_introduction` (empty stub) | RTD `dartpy/user_guide/examples` |
| `dartpy_examples_rigid_cubes` | `dart` repo `python/examples/demos/scenes/rigid_cubes.py` |
| `dartpy_examples_operational_space_control` | `dart` repo `python/examples/demos/scenes/operational_space_control.py` |
| `gallery` | RTD `gallery` |
| `license` | RTD `license` |
| `citing` | RTD `papers` |
| `mydoc_use_cases` | RTD `community/who_uses_dart` |

## Verification

Local `jekyll build` (exit 0). Confirmed in the generated `_site`: each redirected page emits `<meta http-equiv="refresh">` to its target (all targets return HTTP 200); `/ci-status/`, `404`, and the **unique** pages (`faq`, SKEL format, `history`, tutorials, news) are **not** redirected — left serving on purpose.

## Deliberately NOT touched here

The genuinely-unique pages are **stale** and need modernization before they belong on the curated RTD site, so they're left for a follow-up: SKEL file format (self-labeled "buggy", 2015 schema), FAQ (2015; EOL-Gazebo instructions), History (stops at 2019), and the 5 OSG-era tutorials (already retired to a stub on RTD). Nothing is deleted in this PR.
