### PR TITLE
Retire FAQ/history and gitignore .omc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site/
 .jekyll-metadata
 _pdf
 .idea/
+.omc/

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/
 title: FAQ
 permalink: faq.html
 sidebar: home_sidebar

--- a/pages/history.md
+++ b/pages/history.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/
 title: DART History
 keywords: 
 tags: [getting_started]


### PR DESCRIPTION
## Summary

Continues retiring the legacy `dartsim.github.io` content now that docs live on **dart.readthedocs.io**.

- **FAQ** and **history** are 2015–2019 vintage with no current RTD equivalent. Their useful content is dead (the "DART through Gazebo" answer targets EOL classic Gazebo), moved (the "meshes load via Assimp" fact now lives in the new SKEL reference), or preserved in git history. Both now redirect to the RTD landing page.
- Add `.omc/` to `.gitignore` (local OMC session state — should never be tracked).

## Not pruning tag pages (yet)

An earlier revision of this PR removed the theme's `pages/tags/*` pages, but `_layouts/page.html` renders tag buttons (`tag_<tag>.html`) for any still-served page that has matching `tags:` front matter (e.g. `js/mydoc_scroll.html` → `tags: special_layouts`). Removing the tag targets would dangle those links, so the tag pages are kept here. The full theme-machinery prune (tags included) is best done once every remaining page redirects.

## Verification

Local `jekyll build` exit 0: `faq` and `history` emit the meta-refresh to RTD; the SKEL page (`skel_file_format.html`) and `/ci-status` dashboard are untouched.

`skel_file_format.html` stays serving until [dartsim/dart#2877](https://github.com/dartsim/dart/pull/2877) (the new RTD SKEL reference) merges and RTD rebuilds — a small follow-up will then redirect it there.
