### PR TITLE
Redirect SKEL page to its new readthedocs reference

### DIFF
--- a/pages/mydoc_skel_file_format.md
+++ b/pages/mydoc_skel_file_format.md
@@ -1,4 +1,5 @@
 ---
+redirect_to: https://dart.readthedocs.io/en/latest/topics/skel-file-format.html
 title: SKEL File Format
 permalink: skel_file_format.html
 sidebar: home_sidebar


### PR DESCRIPTION
## Summary

Final step of retiring the legacy `dartsim.github.io` content: the **SKEL file format** now has a dedicated, verified reference on readthedocs (added in [dartsim/dart#2877](https://github.com/dartsim/dart/pull/2877)), so redirect the stale 2015 `skel_file_format.html` there.

`skel_file_format.html` → `https://dart.readthedocs.io/en/latest/topics/skel-file-format.html`

## Verification

Local `jekyll build` exit 0: the page emits the meta-refresh to the new RTD page; `/ci-status` is untouched.

> Note: the RTD `latest` build is still publishing the new SKEL page (dart `main` is under heavy activity post-merge). **Hold merge until the target returns 200** — I'm monitoring and will land it once it's live.
